### PR TITLE
_DDOperatorInfo.m : fixing a compilation warning about unused baseInfo

### DIFF
--- a/DDMathParser/_DDOperatorInfo.m
+++ b/DDMathParser/_DDOperatorInfo.m
@@ -51,9 +51,10 @@
         }
         
         // this is to make sure all of the operators are defined correctly
+        _DDOperatorInfo *baseInfo = nil;
         for (NSString *functionName in _operatorLookup) {
             NSArray *operatorInfos = [_operatorLookup objectForKey:functionName];
-            _DDOperatorInfo *baseInfo = [operatorInfos lastObject];
+            baseInfo = [operatorInfos lastObject];
             for (_DDOperatorInfo *info in operatorInfos) {
                 NSAssert([info precedence] == [baseInfo precedence], @"mismatched operator precedences");
                 NSAssert([info arity] == [baseInfo arity], @"mismatched operator arity");


### PR DESCRIPTION
I don't know if it was an optimisation.
This way the change I've made shouldn't have any impact neither on performance nor behavior.
