### PR TITLE
Added modulo alias

### DIFF
--- a/DDMathParser/DDMathEvaluator.m
+++ b/DDMathParser/DDMathEvaluator.m
@@ -205,6 +205,7 @@ static DDMathEvaluator * _sharedEvaluator = nil;
     static NSDictionary *standardAliases = nil;
     dispatch_once(&onceToken, ^{
         standardAliases = [[NSDictionary alloc] initWithObjectsAndKeys:
+                           @"mod", @"modulo",
                            @"average", @"avg",
                            @"average", @"mean",
                            @"floor", @"trunc",


### PR DESCRIPTION
There are two definitions for the modulus function: modulo and mod. The % operator is parsed and replaced with the function 'modulo', but only 'mod' resides in the DDMathEvaluator:registeredFunctions list. This adds an alias for modulo so that the DDMathParser mod function works out of the box.
