### PR TITLE
Resolve a memory leak by breaking a reference cycle in ARC.

### DIFF
--- a/DDMathParser/DDExpression.h
+++ b/DDMathParser/DDExpression.h
@@ -17,7 +17,7 @@ typedef enum {
 @class DDMathEvaluator, DDParser;
 
 @interface DDExpression : NSObject <NSCoding> {
-    DDExpression *_parentExpression;
+    DDExpression * __unsafe_unretained _parentExpression;
 }
 
 @property (nonatomic, readonly) DDExpression *parentExpression;


### PR DESCRIPTION
The cycle orginates in `-[_DDFunctionExpression initWithFunction:arguments:error:]` where each argument holds a strong reference to the function expression, and vise versa. This bug does not occur when using manual reference counting. Note that __unsafe_unretained does nothing when ARC is disabled, so you don't have to write a macro.
