### PR TITLE
Changed defines to iOS compatible version. (LONG_LONG_MIN -> LLONG_MIN)

### DIFF
--- a/DDMathParser/_DDFunctionEvaluator.m
+++ b/DDMathParser/_DDFunctionEvaluator.m
@@ -402,8 +402,8 @@ static NSString *const _DDFunctionSelectorSuffix = @":variables:error:";
 		[params addObject:value];
 	}
 	
-    long long lowerBound = LONG_LONG_MIN;
-    long long upperBound = LONG_LONG_MAX;
+    long long lowerBound = LLONG_MIN;
+    long long upperBound = LLONG_MAX;
 	
 	if ([params count] > 0) {
         lowerBound = [[params objectAtIndex:0] longLongValue];


### PR DESCRIPTION
Hi,

I changed LONG_LONG_MIN and LONG_LONG_MAX to LLONG_MIN and LLONG_MAX now the framework works again on iOS.
