### PR TITLE
Fix unit tests assuming right precedence of pow.

### DIFF
--- a/DDMathParser/DDMathOperator.h
+++ b/DDMathParser/DDMathOperator.h
@@ -18,6 +18,7 @@
 
 + (instancetype)infoForOperatorFunction:(NSString *)function;
 + (NSArray *)infosForOperatorToken:(NSString *)token;
++ (DDOperatorAssociativity)associativityForPowerExpressions;
 
 // the only reason you'd want to init a new \c MathOperator is so you can pass it to the -[DDMathOperatorSet addOperator:...] methods
 - (id)initWithOperatorFunction:(NSString *)function

--- a/DDMathParser/DDMathOperator.m
+++ b/DDMathParser/DDMathOperator.m
@@ -24,6 +24,17 @@
     return [[DDMathOperatorSet defaultOperatorSet] operatorsForToken:token];
 }
 
++ (DDOperatorAssociativity)associativityForPowerExpressions {
+    NSExpression *powerExpression = [NSExpression expressionWithFormat:@"2 ** 3 ** 2"];
+    NSNumber *powerResult = [powerExpression expressionValueWithObject:nil context:nil];
+    DDOperatorAssociativity powerAssociativity = DDOperatorAssociativityLeft;
+    if ([powerResult intValue] == 512) {
+        powerAssociativity = DDOperatorAssociativityRight;
+    }
+
+    return powerAssociativity;
+}
+
 #define UNARY DDOperatorArityUnary
 #define BINARY DDOperatorArityBinary
 #define LEFT DDOperatorAssociativityLeft
@@ -117,13 +128,7 @@
 		//determine what associativity NSPredicate/NSExpression is using
 		//mathematically, it should be right associative, but it's usually parsed as left associative
 		//rdar://problem/8692313
-		NSExpression *powerExpression = [NSExpression expressionWithFormat:@"2 ** 3 ** 2"];
-		NSNumber *powerResult = [powerExpression expressionValueWithObject:nil context:nil];
-        DDOperatorAssociativity powerAssociativity = LEFT;
-		if ([powerResult intValue] == 512) {
-			powerAssociativity = RIGHT;
-		}
-        
+        DDOperatorAssociativity powerAssociativity = [self associativityForPowerExpressions];
         [operators addObject:OPERATOR(DDOperatorPower, (@[@"**"]), BINARY, precedence, powerAssociativity)];
         precedence++;
         

--- a/Unit Tests/EvaluationTests.m
+++ b/Unit Tests/EvaluationTests.m
@@ -49,7 +49,12 @@
 - (void)testPower {
     TEST(@"2**2", 4);
     TEST(@"2**2**2", 16);
-    TEST(@"2**3**2", 512);
+
+    if ([DDMathOperator associativityForPowerExpressions] == DDOperatorAssociativityRight) {
+        TEST(@"2**3**2", 512);
+    } else {
+        TEST(@"2**3**2", 64);
+    }
 }
 
 - (void)testNegation {


### PR DESCRIPTION
The actual implementation determines the precedence of the power
operator during runtime, but the tests use a hard coded value. As a
result, the assertion that "2**3**2 == 512" fails on runtimes which use the
correct, left-precedence evaluation order (such as my OS X 10.9
MacBook). This commit adds the same runtime check to the tests in order
to prevent false negatives in the tests.

---

Thanks a lot for this library, by the way! Have you considered adding it to the CocoaPods spec repository? Would you mind a pull request adding a podspec file?
