### PR TITLE
Added pod spec

### DIFF
--- a/DDMathParser.podspec
+++ b/DDMathParser.podspec
@@ -1,18 +1,18 @@
 Pod::Spec.new do |s|
-  s.name         = "DDMathParser"
-  s.version      = "1.0.0"
-  s.summary      = "NSString ⟹ NSNumber"
+  s.name = "DDMathParser"
+  s.version = "1.0.0"
+  s.summary = "NSString ⟹ NSNumber"
 
-  s.homepage     = "https://github.com/davedelong/DDMathParser"
-  s.license            = 'MIT'
-  s.author             = { "Dave DeLong" => "davedelong@me.com" }
-  s.social_media_url   = "https://twitter.com/davedelong"
+  s.homepage = "https://github.com/davedelong/DDMathParser"
+  s.license = 'MIT'
+  s.author = { "Dave DeLong" => "davedelong@me.com" }
+  s.social_media_url = "https://twitter.com/davedelong"
 
   s.ios.deployment_target = '7.0'
   s.osx.deployment_target = '10.9'
 
-  s.source       = { :git => "https://github.com/davedelong/DDMathParser.git", :commit => "ecc0b7320f599d0d2e7a5d60bfd8c3865e1ba8ec" }
+  s.source = { :git => "https://github.com/davedelong/DDMathParser.git", :commit => "ecc0b7320f599d0d2e7a5d60bfd8c3865e1ba8ec" }
 
-  s.source_files  = 'DDMathParser/*.{h,m}'
+  s.source_files = 'DDMathParser/*.{h,m}'
   s.requires_arc = true
 end


### PR DESCRIPTION
I’ve recently added [DDMathParser](https://github.com/CocoaPods/Specs/tree/master/DDMathParser) to the [CocoaPods](https://github.com/CocoaPods/CocoaPods) package manager repo.

CocoaPods is a tool for managing dependencies for OSX and iOS Xcode projects and provides a central repository for iOS/OSX libraries. This makes adding libraries to a project and updating them extremely easy and it will help users to resolve dependencies of the libraries they use.

However, DDMathParser doesn't have any version tags. I’ve added the current HEAD as version 0.0.1, but a version tag will make dependency resolution much easier.

[Semantic version](http://semver.org) tags (instead of plain commit hashes/revisions) allow for [resolution of cross-dependencies](https://github.com/CocoaPods/Specs/wiki/Cross-dependencies-resolution-example).

In case you didn’t know this yet; you can tag the current HEAD as, for instance, version 1.0.0, like so:

```
$ git tag -a 1.0.0 -m "Tag release 1.0.0"
$ git push --tags
```
