### PR TITLE
Gardening

### DIFF
--- a/MathParser/Expression.swift
+++ b/MathParser/Expression.swift
@@ -80,6 +80,10 @@ public final class Expression {
                 return Expression(kind: .number(value), range: range)
         }
     }
+    
+    public func rewrite(_ substitutions: Substitutions = [:], rewriter: ExpressionRewriter = .default, evaluator: Evaluator = .default) -> Expression {
+        return rewriter.rewriteExpression(self, substitutions: substitutions, evaluator: evaluator)
+    }
 }
 
 extension Expression: CustomStringConvertible {

--- a/MathParser/Expressionizer.swift
+++ b/MathParser/Expressionizer.swift
@@ -88,11 +88,10 @@ public struct Expressionizer {
         
         while wrappers.count > 1 || wrappers.first?.isToken == true {
             let (indices, maybeOp) = operatorWithHighestPrecedence(wrappers)
-            guard let first = indices.first else {
+            guard let first = indices.first, let last = indices.last else {
                 let range: Range<Int> = wrappers.first?.range ?? 0 ..< 0
                 throw MathParserError(kind: .invalidFormat, range: range)
             }
-            guard let last = indices.last else { fatalError("If there's a first, there's a last") }
             guard let op = maybeOp else { fatalError("Indices but no operator??") }
             
             let index = op.associativity == .left ? first : last

--- a/MathParser/String.swift
+++ b/MathParser/String.swift
@@ -10,9 +10,9 @@ import Foundation
 
 public extension String {
     
-    public func evaluate(_ substitutions: Substitutions = [:]) throws -> Double {
+    public func evaluate(using evaluator: Evaluator = .default, _ substitutions: Substitutions = [:]) throws -> Double {
         let e = try Expression(string: self)
-        return try Evaluator.default.evaluate(e, substitutions: substitutions)
+        return try evaluator.evaluate(e, substitutions: substitutions)
     }
     
 }

--- a/MathParserTests/GithubIssues.swift
+++ b/MathParserTests/GithubIssues.swift
@@ -45,7 +45,7 @@ class GithubIssues: XCTestCase {
         guard let d = XCTAssertNoThrows(try "exp(ln(42))".evaluate()) else { return }
         // d is 42.00000000000000711
         // that's pretty close, but we need to fudge in some ε
-        XCTAssertEqualWithAccuracy(d, 42, accuracy: 32 * DBL_EPSILON)
+        XCTAssertEqualWithAccuracy(d, 42, accuracy: 32 * .ulpOfOne)
     }
     
     func testIssue14() {
@@ -55,12 +55,12 @@ class GithubIssues: XCTestCase {
     
     func testIssue15() {
         guard let d = XCTAssertNoThrows(try "sin(π/6)".evaluate()) else { return }
-        XCTAssertEqualWithAccuracy(d, 0.5, accuracy: DBL_EPSILON)
+        XCTAssertEqualWithAccuracy(d, 0.5, accuracy: .ulpOfOne)
     }
     
     func testIssue16() {
         guard let d = XCTAssertNoThrows(try "π * e".evaluate()) else { return }
-        XCTAssertEqual(d, M_PI * M_E)
+        XCTAssertEqual(d, .pi * M_E)
     }
     
     func testIssue19() {
@@ -84,11 +84,11 @@ class GithubIssues: XCTestCase {
         
         guard let e1 = XCTAssertNoThrows(try Expression(string: "sin(45)")) else { return }
         guard let d1 = XCTAssertNoThrows(try eval.evaluate(e1)) else { return }
-        XCTAssertEqualWithAccuracy(d1, M_SQRT2 / 2, accuracy: DBL_EPSILON)
+        XCTAssertEqualWithAccuracy(d1, 2.squareRoot() / 2, accuracy: .ulpOfOne)
         
         guard let e2 = XCTAssertNoThrows(try Expression(string: "sin(π/2)")) else { return }
         guard let d2 = XCTAssertNoThrows(try eval.evaluate(e2)) else { return }
-        XCTAssertEqualWithAccuracy(d2, 0.02741213359204429, accuracy: DBL_EPSILON)
+        XCTAssertEqualWithAccuracy(d2, 0.02741213359204429, accuracy: .ulpOfOne)
         
         
         eval.angleMeasurementMode = .radians
@@ -308,7 +308,7 @@ class GithubIssues: XCTestCase {
         
         let eval = Evaluator.default
         guard let d = XCTAssertNoThrows(try eval.evaluate(e)) else { return }
-        XCTAssertEqual(d, M_PI / 6)
+        XCTAssertEqual(d, .pi / 6)
     }
     
     func testIssue110() {

--- a/MathParserTests/RewriterTests.swift
+++ b/MathParserTests/RewriterTests.swift
@@ -18,6 +18,10 @@ func TestRewrite(_ original: String, expected: String, substitutions: Substituti
     let rewritten = rewriter.rewriteExpression(originalE, substitutions: substitutions, evaluator: evaluator)
     
     XCTAssertEqual(rewritten, expectedE, file: file, line: line)
+    
+    // Also test that the convenience functions produces the same result.
+    let convenienceRewritten = originalE.rewrite(substitutions, rewriter: rewriter, evaluator: evaluator)
+    XCTAssertEqual(convenienceRewritten, rewritten)
 }
 
 class RewriterTests: XCTestCase {

--- a/MathParserTests/TestHelpers.swift
+++ b/MathParserTests/TestHelpers.swift
@@ -50,5 +50,5 @@ func TestString(_ string: String, value: Double, evaluator: Evaluator = Evaluato
     guard let d = XCTAssertNoThrows(try evaluator.evaluate(e), file: file, line: line) else {
         return
     }
-    XCTAssertEqualWithAccuracy(d, value, accuracy: DBL_EPSILON, file: file, line: line)
+    XCTAssertEqualWithAccuracy(d, value, accuracy: .ulpOfOne, file: file, line: line)
 }


### PR DESCRIPTION
This does some cleanup:
- Fix Swift 3.1 deprecations in tests
- Remove usage of `fatalError` by assigning `last` in the same `if let` where `first` is also assigned.

It also adds some more convenience:
- Allow passing an `Evaluator` to the convenience function for evaluating a `String`
- Add convenience function on `Expression` to rewrite the given expression (incl. tests).