### PR TITLE
Nested expressions

### DIFF
--- a/DDMathParser.xcodeproj/project.pbxproj
+++ b/DDMathParser.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		079712FC1EB49A0B003D7C3C /* SubstitutionExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 079712FB1EB49A0B003D7C3C /* SubstitutionExtensions.swift */; };
 		5514B1741B7BDF57007431D0 /* RawToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5514B1731B7BDF57007431D0 /* RawToken.swift */; };
 		5514B1761B7C22D6007431D0 /* TestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5514B1751B7C22D6007431D0 /* TestHelpers.swift */; };
 		5514B1781B7CFD1A007431D0 /* ResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5514B1771B7CFD1A007431D0 /* ResolverTests.swift */; };
@@ -69,6 +70,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		079712FB1EB49A0B003D7C3C /* SubstitutionExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SubstitutionExtensions.swift; sourceTree = "<group>"; };
 		08FB779EFE84155DC02AAC07 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = /System/Library/Frameworks/Foundation.framework; sourceTree = "<absolute>"; };
 		3D80DDD019BA9163008C2E6C /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
 		5514B1731B7BDF57007431D0 /* RawToken.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RawToken.swift; sourceTree = "<group>"; };
@@ -189,6 +191,7 @@
 			isa = PBXGroup;
 			children = (
 				551C2D231B8B6A5C00876E68 /* String.swift */,
+				079712FB1EB49A0B003D7C3C /* SubstitutionExtensions.swift */,
 			);
 			name = Convenience;
 			sourceTree = "<group>";
@@ -435,6 +438,7 @@
 				551C2D241B8B6A5C00876E68 /* String.swift in Sources */,
 				552781531B75234F0093B070 /* QuotedVariableExtractor.swift in Sources */,
 				552CE1C81B938F15007B89A1 /* ExponentExtractor.swift in Sources */,
+				079712FC1EB49A0B003D7C3C /* SubstitutionExtensions.swift in Sources */,
 				5527814F1B751DD40093B070 /* VariableExtractor.swift in Sources */,
 				5527814D1B751DCC0093B070 /* IdentifierExtractor.swift in Sources */,
 				554AF6B41CDCED3E00C2583E /* MathParserErrors.swift in Sources */,

--- a/MathParser/DynamicResolution.swift
+++ b/MathParser/DynamicResolution.swift
@@ -25,11 +25,16 @@ public protocol Substitution {
     func substitutionValue(using evaluator: Evaluator) throws -> Double
     
     func simplified(using evaluator: Evaluator, substitutions: Substitutions) -> Substitution
+    func simplified(using evaluator: Evaluator) -> Substitution
 }
 
 public extension Substitution {
     func substitutionValue(using evaluator: Evaluator) throws -> Double {
         return try substitutionValue(using: evaluator, substitutions: [:])
+    }
+    
+    func simplified(using evaluator: Evaluator) -> Substitution {
+        return simplified(using: evaluator, substitutions: [:])
     }
 }
 

--- a/MathParser/DynamicResolution.swift
+++ b/MathParser/DynamicResolution.swift
@@ -20,4 +20,17 @@ public protocol VariableResolver {
     func resolveVariable(_ variable: String) -> Double?
 }
 
-public typealias Substitutions = Dictionary<String, Double>
+public protocol Substitution {
+    func substitutionValue(using evaluator: Evaluator, substitutions: Substitutions) throws -> Double
+    func substitutionValue(using evaluator: Evaluator) throws -> Double
+    
+    func simplified(using evaluator: Evaluator, substitutions: Substitutions) -> Substitution
+}
+
+public extension Substitution {
+    func substitutionValue(using evaluator: Evaluator) throws -> Double {
+        return try substitutionValue(using: evaluator, substitutions: [:])
+    }
+}
+
+public typealias Substitutions = Dictionary<String, Substitution>

--- a/MathParser/Evaluator.swift
+++ b/MathParser/Evaluator.swift
@@ -52,7 +52,9 @@ public struct Evaluator {
     }
     
     private func evaluateVariable(_ name: String, substitutions: Substitutions, range: Range<Int>) throws -> Double {
-        if let value = substitutions[name] { return value }
+        if let value = try substitutions[name]?.substitutionValue(using: self, substitutions: substitutions) {
+            return value
+        }
         
         // substitutions were insufficient
         // use the variable resolver

--- a/MathParser/Expression.swift
+++ b/MathParser/Expression.swift
@@ -60,7 +60,11 @@ public final class Expression {
     public func simplify(_ substitutions: Substitutions = [:], evaluator: Evaluator) -> Expression {
         switch kind {
             case .number(_): return Expression(kind: kind, range: range)
-            case .variable(_):
+            case .variable(let varName):
+                if let exp = substitutions[varName] as? Expression {
+                    let newKind = exp.simplify(substitutions, evaluator: evaluator).kind
+                    return Expression(kind: newKind, range: range)
+                }
                 if let resolved = try? evaluator.evaluate(self, substitutions: substitutions) {
                     return Expression(kind: .number(resolved), range: range)
                 }

--- a/MathParser/Expression.swift
+++ b/MathParser/Expression.swift
@@ -80,6 +80,10 @@ public final class Expression {
                 return Expression(kind: .number(value), range: range)
         }
     }
+    
+    public func rewrite(_ substitutions: Substitutions = [:], rewriter: ExpressionRewriter = .default, evaluator: Evaluator = .default) -> Expression {
+        return rewriter.rewriteExpression(self, substitutions: substitutions, evaluator: evaluator)
+    }
 }
 
 extension Expression: CustomStringConvertible {

--- a/MathParser/Expression.swift
+++ b/MathParser/Expression.swift
@@ -61,12 +61,11 @@ public final class Expression {
         switch kind {
             case .number(_): return Expression(kind: kind, range: range)
             case .variable(let varName):
-                if let exp = substitutions[varName] as? Expression {
-                    let newKind = exp.simplify(substitutions, evaluator: evaluator).kind
-                    return Expression(kind: newKind, range: range)
-                }
                 if let resolved = try? evaluator.evaluate(self, substitutions: substitutions) {
                     return Expression(kind: .number(resolved), range: range)
+                }
+                if let exp = substitutions[varName]?.simplified(using: evaluator, substitutions: substitutions) as? Expression {
+                    return Expression(kind: exp.kind, range: range)
                 }
                 return Expression(kind: kind, range: range)
             case let .function(f, args):

--- a/MathParser/Expression.swift
+++ b/MathParser/Expression.swift
@@ -86,6 +86,16 @@ public final class Expression {
     }
 }
 
+extension Expression: Substitution {
+    public func substitutionValue(using evaluator: Evaluator, substitutions: Substitutions) throws -> Double {
+        return try evaluator.evaluate(self, substitutions: substitutions)
+    }
+    
+    public func simplified(using evaluator: Evaluator, substitutions: Substitutions) -> Substitution {
+        return simplify(substitutions, evaluator: evaluator)
+    }
+}
+
 extension Expression: CustomStringConvertible {
     
     public var description: String {

--- a/MathParser/Expressionizer.swift
+++ b/MathParser/Expressionizer.swift
@@ -88,11 +88,10 @@ public struct Expressionizer {
         
         while wrappers.count > 1 || wrappers.first?.isToken == true {
             let (indices, maybeOp) = operatorWithHighestPrecedence(wrappers)
-            guard let first = indices.first else {
+            guard let first = indices.first, let last = indices.last else {
                 let range: Range<Int> = wrappers.first?.range ?? 0 ..< 0
                 throw MathParserError(kind: .invalidFormat, range: range)
             }
-            guard let last = indices.last else { fatalError("If there's a first, there's a last") }
             guard let op = maybeOp else { fatalError("Indices but no operator??") }
             
             let index = op.associativity == .left ? first : last

--- a/MathParser/Info.plist
+++ b/MathParser/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.0</string>
+	<string>3.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/MathParser/String.swift
+++ b/MathParser/String.swift
@@ -10,9 +10,9 @@ import Foundation
 
 public extension String {
     
-    public func evaluate(_ substitutions: Substitutions = [:]) throws -> Double {
+    public func evaluate(using evaluator: Evaluator = .default, _ substitutions: Substitutions = [:]) throws -> Double {
         let e = try Expression(string: self)
-        return try Evaluator.default.evaluate(e, substitutions: substitutions)
+        return try evaluator.evaluate(e, substitutions: substitutions)
     }
     
 }

--- a/MathParser/SubstitutionExtensions.swift
+++ b/MathParser/SubstitutionExtensions.swift
@@ -1,0 +1,50 @@
+//
+//  SubstitutionExtensions.swift
+//  DDMathParser
+//
+//  Created by Florian Friedrich on 29.04.17.
+//
+//
+
+import Foundation
+
+extension Double: Substitution {
+    public func substitutionValue(using evaluator: Evaluator, substitutions: Substitutions) throws -> Double {
+        return self
+    }
+    
+    public func simplified(using evaluator: Evaluator, substitutions: Substitutions) -> Substitution {
+        return self
+    }
+}
+
+extension Int: Substitution {
+    public func substitutionValue(using evaluator: Evaluator, substitutions: Substitutions) throws -> Double {
+        return Double(self)
+    }
+    
+    public func simplified(using evaluator: Evaluator, substitutions: Substitutions) -> Substitution {
+        return Double(self)
+    }
+}
+
+extension String: Substitution {
+    public func substitutionValue(using evaluator: Evaluator, substitutions: Substitutions) throws -> Double {
+        return try evaluate(using: evaluator, substitutions)
+    }
+    
+    public func simplified(using evaluator: Evaluator, substitutions: Substitutions) -> Substitution {
+        // If it's just a Double as String -> Return it as such
+        if let double = Double(self) {
+            return double
+        }
+        
+        // If it can be expressed as exression, return the simplified expression
+        if let exp = try? Expression(string: self) {
+            return exp.simplified(using: evaluator, substitutions: substitutions)
+        }
+        
+        // If it's neither, return self. This will likely fail in evaluation later.
+        return self
+    }
+}

--- a/MathParserTests/EvaluatorTests.swift
+++ b/MathParserTests/EvaluatorTests.swift
@@ -21,6 +21,12 @@ class EvaluatorTests: XCTestCase {
         XCTAssertEqual(d, 42)
     }
     
+    func testVariableWithNestedExpression() {
+        guard let sub = XCTAssertNoThrows(try Expression(string: "21 * 2")) else { return }
+        guard let d = XCTAssertNoThrows(try "$foo".evaluate(["foo": sub])) else { return }
+        XCTAssertEqual(d, 42)
+    }
+    
     func testFunction() {
         guard let d = XCTAssertNoThrows(try "1 + 2".evaluate()) else { return }
         XCTAssertEqual(d, 3)

--- a/MathParserTests/ExpressionTests.swift
+++ b/MathParserTests/ExpressionTests.swift
@@ -325,4 +325,13 @@ class ExpressionTests: XCTestCase {
         }
     }
     
+    func testSimplifyWithNestedExpressions() {
+        guard let e = XCTAssertNoThrows(try Expression(string: "$foo * 2 + $bar")) else { return }
+        guard let foo = XCTAssertNoThrows(try Expression(string: "$bar + 2")) else { return }
+        
+        let simplified = e.simplify(["foo": foo], evaluator: .default)
+        guard let expectedResult = XCTAssertNoThrows(try Expression(string: "($bar + 2) * 2 + $bar")) else { return }
+        XCTAssertEqual(simplified, expectedResult)
+    }
+    
 }

--- a/MathParserTests/GithubIssues.swift
+++ b/MathParserTests/GithubIssues.swift
@@ -45,7 +45,7 @@ class GithubIssues: XCTestCase {
         guard let d = XCTAssertNoThrows(try "exp(ln(42))".evaluate()) else { return }
         // d is 42.00000000000000711
         // that's pretty close, but we need to fudge in some ε
-        XCTAssertEqualWithAccuracy(d, 42, accuracy: 32 * DBL_EPSILON)
+        XCTAssertEqualWithAccuracy(d, 42, accuracy: 32 * .ulpOfOne)
     }
     
     func testIssue14() {
@@ -55,12 +55,12 @@ class GithubIssues: XCTestCase {
     
     func testIssue15() {
         guard let d = XCTAssertNoThrows(try "sin(π/6)".evaluate()) else { return }
-        XCTAssertEqualWithAccuracy(d, 0.5, accuracy: DBL_EPSILON)
+        XCTAssertEqualWithAccuracy(d, 0.5, accuracy: .ulpOfOne)
     }
     
     func testIssue16() {
         guard let d = XCTAssertNoThrows(try "π * e".evaluate()) else { return }
-        XCTAssertEqual(d, M_PI * M_E)
+        XCTAssertEqual(d, .pi * M_E)
     }
     
     func testIssue19() {
@@ -84,11 +84,11 @@ class GithubIssues: XCTestCase {
         
         guard let e1 = XCTAssertNoThrows(try Expression(string: "sin(45)")) else { return }
         guard let d1 = XCTAssertNoThrows(try eval.evaluate(e1)) else { return }
-        XCTAssertEqualWithAccuracy(d1, M_SQRT2 / 2, accuracy: DBL_EPSILON)
+        XCTAssertEqualWithAccuracy(d1, 2.squareRoot() / 2, accuracy: .ulpOfOne)
         
         guard let e2 = XCTAssertNoThrows(try Expression(string: "sin(π/2)")) else { return }
         guard let d2 = XCTAssertNoThrows(try eval.evaluate(e2)) else { return }
-        XCTAssertEqualWithAccuracy(d2, 0.02741213359204429, accuracy: DBL_EPSILON)
+        XCTAssertEqualWithAccuracy(d2, 0.02741213359204429, accuracy: .ulpOfOne)
         
         
         eval.angleMeasurementMode = .radians
@@ -308,7 +308,7 @@ class GithubIssues: XCTestCase {
         
         let eval = Evaluator.default
         guard let d = XCTAssertNoThrows(try eval.evaluate(e)) else { return }
-        XCTAssertEqual(d, M_PI / 6)
+        XCTAssertEqual(d, .pi / 6)
     }
     
     func testIssue110() {

--- a/MathParserTests/RewriterTests.swift
+++ b/MathParserTests/RewriterTests.swift
@@ -18,6 +18,10 @@ func TestRewrite(_ original: String, expected: String, substitutions: Substituti
     let rewritten = rewriter.rewriteExpression(originalE, substitutions: substitutions, evaluator: evaluator)
     
     XCTAssertEqual(rewritten, expectedE, file: file, line: line)
+    
+    // Also test that the convenience functions produces the same result.
+    let convenienceRewritten = originalE.rewrite(substitutions, rewriter: rewriter, evaluator: evaluator)
+    XCTAssertEqual(convenienceRewritten, rewritten)
 }
 
 class RewriterTests: XCTestCase {

--- a/MathParserTests/TestHelpers.swift
+++ b/MathParserTests/TestHelpers.swift
@@ -50,5 +50,5 @@ func TestString(_ string: String, value: Double, evaluator: Evaluator = Evaluato
     guard let d = XCTAssertNoThrows(try evaluator.evaluate(e), file: file, line: line) else {
         return
     }
-    XCTAssertEqualWithAccuracy(d, value, accuracy: DBL_EPSILON, file: file, line: line)
+    XCTAssertEqualWithAccuracy(d, value, accuracy: .ulpOfOne, file: file, line: line)
 }


### PR DESCRIPTION
This essentially only adds one feature over #135 yet needs the commits from #135. However, git should be able to merge this.

This allows to do something like this:

```swift
do {
    let exp = try Expression(string: "$a + 5 - $b + $a")
    // -> $a + 5.0 - $b + $a
    let a = try Expression(string: "$b - 2")
    // -> $b - 2.0
    let b = 4.0
    // -> 4.0
    let simplified = exp.simplify(["a": a], evaluator: .default)
    // -> $b - 2.0 + 5.0 - $b + $b - 2.0
    let result = try Evaluator.default.evaluate(exp, substitutions: ["a": a, "b": b])
    // -> 5.0
} catch {
    print("Failed: \(error)")
}
```