### PR TITLE
Add public init for MathParserError

### DIFF
--- a/MathParser/MathParserErrors.swift
+++ b/MathParser/MathParserErrors.swift
@@ -50,6 +50,11 @@ public struct MathParserError: Error {
     
     // the location within the original source string where the error was found
     public let range: Range<Int>
+
+    public init(kind: Kind, range: Range<Int>) {
+        self.kind = kind
+        self.range = range
+    }
 }
 
 extension MathParserError.Kind: Equatable { }


### PR DESCRIPTION
In Swift 4.1, you can't create an extension in another project adding an initializer that doesn't delegate (see [SE-0189](https://github.com/apple/swift-evolution/blob/master/proposals/0189-restrict-cross-module-struct-initializers.md)).
While this does not affect DDMathParser itself, it affected us since we re-use the `MathParserError` in our code to prevent having to add basically the same error type again.
This PR simply adds a public init to the error type. Since it has the same interface as the previously compiler-provided initializer, it should be fully compatible with existing code - even in Swift versions before 4.1. The latter is why I didn't conditionally include this initializer (`#if swift(>4.1)`)...