### PR TITLE
Fix source_files file path in podspec

### DIFF
--- a/DDMathParser.podspec
+++ b/DDMathParser.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   s.osx.deployment_target = '10.9'
   s.watchos.deployment_target = '2.0'
 
-  s.source_files = 'MathParser/*.{h,m,swift}'
+  s.source_files = 'MathParser/Sources/MathParser/*.{h,m,swift}'
 
   s.requires_arc = true
   s.module_name = 'MathParser'


### PR DESCRIPTION
The addition of the Swift Package file changed the file path for the math parser's source files. This change updates the podspec with the new source_files file path.