### PR TITLE
Move SwiftPM Manifest to Repo Root

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -20,9 +20,11 @@ let package = Package(
         // Targets can depend on other targets in this package, and on products in packages which this package depends on.
         .target(
             name: "MathParser",
-            dependencies: []),
+            dependencies: [],
+            path: "MathParser/Sources/MathParser"),
         .testTarget(
             name: "MathParserTests",
-            dependencies: ["MathParser"]),
+            dependencies: ["MathParser"],
+            path: "MathParser/Tests/MathParserTests"),
     ]
 )


### PR DESCRIPTION
Afaik SwiftPM currently only supports packages which contain their manifest in the repository's root directory. I'm unable to declare this package as a dependency of mine in its current form.

Since targets support custom paths though, this is easily fixed by only moving the package manifest.

Huge thanks for the project by the way!

This also fixes #146.