### PR TITLE
Updated to fix -neg num for cube root

### DIFF
--- a/MathParser/Sources/MathParser/Functions+Defaults.swift
+++ b/MathParser/Sources/MathParser/Functions+Defaults.swift
@@ -146,7 +146,12 @@ extension Function {
         
         let arg1 = try state.evaluator.evaluate(state.arguments[0], substitutions: state.substitutions)
         
-        return Darwin.pow(arg1, 1.0/3.0)
+        if arg1 < 0 {
+            let root = Darwin.pow(-arg1, 1.0/3.0)
+            return -root
+        } else {
+            return Darwin.pow(arg1, 1.0/3.0)
+        }
     })
     
     public static let nthroot = Function(name: "nthroot", evaluator: { state throws -> Double in


### PR DESCRIPTION
Hi there, I was working on an app and realised that if I did ∛ any negative number, eg ∛-27, it will return NaN. However, using nthroot(-27,3) returns the correct result (-3).

Searched through past closed issues and realised that you have fixed the issue on nthroot but may have missed out the same change on ∛/cuberoot. I did some minor changes to the ∛ code based on the nthroot and it seemed to be working fine. 

Submitting a pull request to help everyone.

Also, would like to take the chance to thank you for the amazing library :)