### PR TITLE
Add Swift 5.2 support, fix warning

### DIFF
--- a/MathParser/Sources/MathParser/Deprecations.swift
+++ b/MathParser/Sources/MathParser/Deprecations.swift
@@ -24,8 +24,8 @@ public struct TokenResolverOptions: OptionSet {
     public init(rawValue: UInt) {
         self.rawValue = rawValue
     }
-    
-    public static let none = TokenResolverOptions(rawValue: 0)
+
+    public static let none: TokenResolverOptions = []
     public static let allowArgumentlessFunctions = TokenResolverOptions(rawValue: 1 << 0)
     public static let allowImplicitMultiplication = TokenResolverOptions(rawValue: 1 << 1)
     public static let useHighPrecedenceImplicitMultiplication = TokenResolverOptions(rawValue: 1 << 2)

--- a/Package@swift-5.1.swift
+++ b/Package@swift-5.1.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.2
+// swift-tools-version:5.1
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription


### PR DESCRIPTION
This adds Swift 5.2 support (while maintaining 5.1 support).
Also, a warning was fixed that stated that `TokenResolverOptions.none` (deprecated) lead to an empty option set. Since this is intentional (and deprecated either way), I applied the suggested fix.