### PR TITLE
Implement random function to be similar to Python random.uniform()

### DIFF
--- a/MathParser/Sources/MathParser/Functions+Defaults.swift
+++ b/MathParser/Sources/MathParser/Functions+Defaults.swift
@@ -179,15 +179,23 @@ extension Function {
             let argValue = try state.evaluator.evaluate(arg, substitutions: state.substitutions)
             argValues.append(argValue)
         }
-        
-        let lowerBound = argValues.count > 0 ? argValues[0] : Double.leastNormalMagnitude
-        let upperBound = argValues.count > 1 ? argValues[1] : Double.greatestFiniteMagnitude
+        var lowerBound = 0.0
+        var upperBound = 1.0
+        switch argValues.count {
+        case 1:
+            upperBound = argValues[0]
+        case 2:
+            lowerBound = argValues[0]
+            upperBound = argValues[1]
+        default:
+            break
+        }
         
         guard lowerBound < upperBound else { throw MathParserError(kind: .invalidArguments, range: state.expressionRange) }
         
         let range = upperBound - lowerBound
         
-        return (drand48().truncatingRemainder(dividingBy: range)) + lowerBound
+        return drand48() * range + lowerBound
     })
     
     public static let log = Function(name: "log", evaluator: { state throws -> Double in

--- a/MathParser/Tests/MathParserTests/GithubIssues.swift
+++ b/MathParser/Tests/MathParserTests/GithubIssues.swift
@@ -377,4 +377,31 @@ class GithubIssues: XCTestCase {
         guard let d2 = XCTAssertNoThrows(try "-2++3".evaluate()) else { return }
         XCTAssertEqual(d2, 1)
     }
+    
+    func testIssue158() {
+        srand48(282828)
+        guard let d1 = XCTAssertNoThrows(try "random()".evaluate()) else { return }
+        XCTAssertLessThanOrEqual(d1, 0.4662)
+        XCTAssertGreaterThanOrEqual(0.4661, d1)
+        
+        srand48(298298)
+        guard let d2 = XCTAssertNoThrows(try "random(100)".evaluate()) else { return }
+        XCTAssertLessThanOrEqual(d2, 75.79)
+        XCTAssertLessThanOrEqual(75.78, d2)
+        
+        srand48(828282)
+        var total: Double = 0.0
+        for _ in 1..<10 {
+            guard let d3 = XCTAssertNoThrows(try "random(100,600)".evaluate()) else { return }
+            total += d3
+        }
+        XCTAssertGreaterThanOrEqual(total / 10, 270)
+        XCTAssertLessThanOrEqual(total / 10, 271)
+        
+        srand48(400400)
+        guard let d4 = XCTAssertNoThrows(try "random(-10.0, 10.0)".evaluate()) else { return }
+        XCTAssertLessThanOrEqual(d4, -1.69)
+        XCTAssertLessThanOrEqual( -1.70, d4)
+        
+    }
 }


### PR DESCRIPTION
Resolves #158, resolves #160 
Since python is popular now in data analysis. I chose to redo the random function to match the argument behaviour in Python.

No arguments gives random 0-1
One argument gives random 0-argument 
Two arguments gives random between first-second

A test in the GitHub issues tests was added with srand48 to force a seed so the test is repeatable. 

It could be a breaking change if someone is using the flawed current version with arguments. I believe random() will not break. There seems to be no base level testing.

The Wiki should be appended to include the one argument behaviour. Possibly also advising anyone that uses the function that they should use srand48 to give a more random starting seed.